### PR TITLE
Update org.kde.Platform to 6.3

### DIFF
--- a/org.linux_hardware.hw-probe.yaml
+++ b/org.linux_hardware.hw-probe.yaml
@@ -1,6 +1,6 @@
 app-id: org.linux_hardware.hw-probe
 runtime: org.kde.Platform
-runtime-version: "6.2"
+runtime-version: "6.3"
 sdk: org.kde.Sdk
 command: hw-probe
 finish-args:


### PR DESCRIPTION
better than 6.2, even if it is EOL